### PR TITLE
Resolves the issue with a symlink removal

### DIFF
--- a/internal/pkg/srm/files.go
+++ b/internal/pkg/srm/files.go
@@ -35,7 +35,7 @@ func doesPathExist(path string) bool {
 }
 
 func isPathADir(path string) bool {
-	fi, err := os.Stat(path)
+	fi, err := os.Lstat(path)
 	if err != nil {
 		return false
 	}
@@ -50,7 +50,7 @@ func isPathADir(path string) bool {
 }
 
 func getFileSize(path string) datasize.ByteSize {
-	fi, err := os.Stat(path)
+	fi, err := os.Lstat(path)
 	if err != nil {
 		return datasize.ByteSize(0)
 	}

--- a/internal/pkg/srm/list.go
+++ b/internal/pkg/srm/list.go
@@ -190,7 +190,7 @@ func sortByTime(cache []*Entry) {
 //
 //func getFileDate(path string) string {
 //	fileDate := ""
-//	finfo, err := os.Stat(path)
+//	finfo, err := os.Lstat(path)
 //	if err != nil {
 //		fileDate = "[unknown]"
 //		return fileDate

--- a/internal/pkg/srm/recover.go
+++ b/internal/pkg/srm/recover.go
@@ -32,7 +32,7 @@ func (m *Manager) Recover(index int) error {
 	// Only try 10 times
 	tmpName := fileName
 	for i := 1; i < 11; i++ {
-		if _, err := os.Stat(tmpName); err == nil {
+		if _, err := os.Lstat(tmpName); err == nil {
 			tmpName = fileName + "." + strconv.Itoa(i)
 		} else {
 			fileName = tmpName


### PR DESCRIPTION
Replaces ``os.Stat`` with ``os.Lstat`` to resolve the issue with a symlink removal, which emerges when **a symlink is targeted to a directory**

The thing is ``os.Stat`` **follows symlinks** by default thus returned ``FileInfo`` describes the target file system entity (``directory``) instead of a symlink itself

This makes removal of a symlink targeted to a directory completely not possible 'cause the command ``srm <a symlink targeted to a directory>`` fails with the statement ``srm: <a symlink targeted to a directory>: is a directory``

[**os.Lstat**](https://cs.opensource.google/go/go/+/go1.20.4:src/os/stat.go;l=20) delivers exactly the same ``FileInfo`` data structure for a file system entity and implements the same subroutines as [**os.Stat**](https://cs.opensource.google/go/go/+/go1.20.4:src/os/stat.go;l=11) does except for symlink processing. **If the file system entity is a symlink, the** ``FileInfo``
**returned by** ``os.Lstat`` **describes that symlink, and** ``os.Lstat`` **makes no attempt to follow it**

Please inspect the following screenshots for visual details 

![1](https://i.im.ge/2023/05/28/hh1lSG.ZNMOK-EKRANA-2023-05-28-O-03-19-39.png)
![2](https://i.im.ge/2023/05/28/hh1rNx.ZNMOK-EKRANA-2023-05-28-O-03-20-23.png)
![3](https://i.im.ge/2023/05/28/hh1oJL.ZNMOK-EKRANA-2023-05-28-O-03-20-54.png)